### PR TITLE
Add Playwright E2E smoke tests (production-like build)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,29 @@
+name: E2E (Playwright)
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+      - name: Run E2E
+        run: npm run test:e2e
+      - name: Upload Playwright report (always)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          if-no-files-found: ignore

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+test('smoke: app loads and primary interaction works', async ({ page }) => {
+  await page.goto('http://127.0.0.1:4173/');
+
+  // App should render something non-empty.
+  await expect(page.locator('body')).toContainText(/\S+/);
+
+  // Heuristic: try the first button and ensure something changes.
+  const btn = page.getByRole('button').first();
+  if (await btn.count()) {
+    const before = await page.locator('body').innerText();
+    await btn.click();
+    const after = await page.locator('body').innerText();
+    expect(after).not.toEqual(before);
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microsoft-pay-calculator",
-  "version": "0.0.1",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microsoft-pay-calculator",
-      "version": "0.0.1",
+      "version": "0.1.6",
       "dependencies": {
         "@architectural-discipline/monorepo": "github:plures/adp",
         "@tauri-apps/plugin-store": "^2.4.1",
@@ -16,6 +16,7 @@
         "@architectural-discipline/cli": "github:plures/adp",
         "@architectural-discipline/core": "github:plures/adp",
         "@architectural-discipline/eslint-plugin": "github:plures/adp",
+        "@playwright/test": "^1.50.1",
         "@sveltejs/adapter-auto": "^6.0.0",
         "@sveltejs/adapter-static": "^3.0.10",
         "@sveltejs/kit": "^2.22.0",
@@ -573,6 +574,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.1.tgz",
+      "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -1574,6 +1591,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
+      "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
+      "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -34,12 +34,15 @@
     "adp:check": "tsx node_modules/@architectural-discipline/monorepo/packages/cli/src/cli.ts analyze --format json",
     "template:create": "node cli/bootstrap.js",
     "plugin:list": "node cli/plugin-list.js",
-    "plugin:add": "node cli/plugin-add.js"
+    "plugin:add": "node cli/plugin-add.js",
+    "test:e2e": "playwright test",
+    "test": "npm run test:e2e"
   },
   "devDependencies": {
     "@architectural-discipline/cli": "github:plures/adp",
     "@architectural-discipline/core": "github:plures/adp",
     "@architectural-discipline/eslint-plugin": "github:plures/adp",
+    "@playwright/test": "^1.50.1",
     "@sveltejs/adapter-auto": "^6.0.0",
     "@sveltejs/adapter-static": "^3.0.10",
     "@sveltejs/kit": "^2.22.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  retries: 1,
+  use: {
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  webServer: {
+    command: 'npm run build && npm run preview -- --host 127.0.0.1 --port 4173',
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});


### PR DESCRIPTION
Adds Playwright E2E smoke testing against built output (npm run build + preview) and uploads traces on failure.

Goal: prevent "build green, UI broken" releases by verifying at least one real interaction in a browser.

Note: Local run currently fails because the repo appears to be missing `src/app.html` (SvelteKit expects it). This PR is intended to surface that failure in CI until the template is fixed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CI job that builds and serves the app and runs browser automation, which can introduce flaky failures and lengthen CI but doesn’t change production runtime behavior.
> 
> **Overview**
> Adds Playwright-based E2E smoke coverage that runs against a production-like `vite build` + `vite preview` web server.
> 
> Introduces a new GitHub Actions workflow (`.github/workflows/e2e.yml`) to run `npm run test:e2e` on PRs and `main`, installs Playwright browsers, and uploads the Playwright report artifacts.
> 
> Updates tooling to support this: adds `@playwright/test` (and Playwright) dev dependencies, adds `test:e2e`/`test` scripts, and includes a minimal `e2e/smoke.spec.ts` plus `playwright.config.ts` (retries, trace/screenshot on failure, webServer on `127.0.0.1:4173`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 674dc27f7ab28e7bbea7a71b5346ccc27fb52a42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->